### PR TITLE
Refactor unpaid function for clarity and date fix

### DIFF
--- a/server/lib/calcEarnings.js
+++ b/server/lib/calcEarnings.js
@@ -114,6 +114,7 @@ async function total(year, month, user, report) {
  * @param {number} [month] month to exclude
  * @returns {Promise<UnpaidEarnings>}
  */
+
 async function unpaid(user, year, month) {
   let earnings = 0;
   const ids = [];
@@ -122,11 +123,20 @@ async function unpaid(user, year, month) {
     [UserEarnings.PAYMENT_ID, null],
   ];
 
+  // Exclude current or future months if year/month is passed
   if (year && month) {
-    where.push([UserEarnings.MONTH, month, '<'], [UserEarnings.YEAR, year], 'OR', [UserEarnings.YEAR, year, '<']);
+    where.push(
+      [UserEarnings.MONTH, month, '<'],
+      [UserEarnings.YEAR, year],
+      'OR',
+      [UserEarnings.YEAR, year, '<']
+    );
   }
 
-  const unpaidEarnings = await UserEarnings.get([UserEarnings.AMOUNT, UserEarnings.ID, UserEarnings.MONTH, UserEarnings.YEAR], where);
+  const unpaidEarnings = await UserEarnings.get(
+    [UserEarnings.AMOUNT, UserEarnings.ID, UserEarnings.MONTH, UserEarnings.YEAR],
+    where
+  );
 
   let fromMonth = 31;
   let fromYear = 9999;
@@ -151,11 +161,24 @@ async function unpaid(user, year, month) {
   }
 
   earnings = Number.parseFloat(Math.round(earnings * 100) / 100);
+
+  // ✅ Fix: Adjust 'to' date so it doesn’t go beyond current date
+  const now = moment();
+  let toMoment = moment({ year: toYear, month: toMonth });
+
+  if (toMoment.isSame(now, 'month') && toMoment.isSame(now, 'year')) {
+    // If unpaid includes the current month, cap it at today
+    toMoment = now.endOf('day');
+  } else {
+    // Otherwise use the full month end
+    toMoment = toMoment.endOf('month');
+  }
+
   return {
     ids,
     earnings,
     from: moment({ year: fromYear, month: fromMonth }).startOf('month'),
-    to: moment({ year: toYear, month: toMonth }).endOf('month'),
+    to: toMoment,
   };
 }
 


### PR DESCRIPTION
The previous function logic was generating end of the month despite current date which may be Future time and may be confusing to users. The current function just makes the unpaid earnings "To date" "current day date"