### PR TITLE
add: error msgs when no plugin is present

### DIFF
--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -665,7 +665,7 @@ async function exploreZip(file) {
   const iconFile = zip.file(iconPath);
   let icon = null;
   if (iconFile) {
-    icon = await iconFile.async('base64');
+    icon = await iconFile?.async('base64');
   } else if (iconPath !== 'icon.png') {
     // If custom path failed, try the default path
     const defaultIconFile = zip.file('icon.png');
@@ -718,6 +718,10 @@ function validatePlugin(json, icon, readmeFile) {
 
   if (!readmeFile) {
     throw new Error('Missing readme.md file.');
+  }
+
+  if (!icon) {
+    throw new Error('Unable to load plugin icon: no icon was provided or the default icon (icon.png) is missing.');
   }
 
   const { name, version, main, license, contributors, keywords } = json;


### PR DESCRIPTION
This commit adds Error msgs when no plugin icon is provided, Also disables the submit btn when there's a error, no zip file is uploaded - with addition to ariaDisabled for the btn & displays this error later instead of short-circuiting to show the user what's fine; Adds the Same Error message On Server Side & handles related errors(null/undefined) for it.
