### PR TITLE
fix: migrate from defaultPrice to purchaseOptions with worldwide regi…

### DIFF
--- a/scripts/sync-plugin-prices.js
+++ b/scripts/sync-plugin-prices.js
@@ -93,7 +93,7 @@ async function upsertOneTimeProduct(plugin, sku, packageName, regionPricing) {
   }
 
   const newConfigs = Object.entries(regionPricing.regionPrices).map(([regionCode, region]) => {
-    const units = region.price.units || 0;
+    const units = Number(region.price.units) || 0;
     const nanos = region.price.nanos || 0;
     return {
       regionCode,
@@ -206,7 +206,13 @@ async function main() {
   console.log('Authenticated with Google Play API\n');
 
   const plugins = getPaidPlugins();
-  const targetSku = process.argv.includes('--sku') ? process.argv[process.argv.indexOf('--sku') + 1] : null;
+  const skuIdx = process.argv.indexOf('--sku');
+  const targetSku = skuIdx !== -1 ? process.argv[skuIdx + 1] : null;
+
+  if (skuIdx !== -1 && (!targetSku || targetSku.startsWith('--'))) {
+    console.log('Error: --sku flag requires a SKU value');
+    return;
+  }
 
   if (targetSku) {
     const filtered = plugins.filter((p) => getPluginSKU(p.id) === targetSku);
@@ -235,7 +241,7 @@ async function main() {
     const allOk = statuses.every((s) => s.startsWith('OK'));
     console.log(`  ${allOk ? 'OK' : 'HAD ERRORS'}\n`);
 
-    if (plugins.length > 1) {
+    if (results.length < plugins.length) {
       await sleep(500);
     }
   }

--- a/scripts/sync-plugin-prices.js
+++ b/scripts/sync-plugin-prices.js
@@ -36,22 +36,47 @@ function flattenErrors(err) {
   return all;
 }
 
-async function getRegionsVersion() {
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getRegionPricing(price) {
   try {
     const res = await androidpublisher.monetization.convertRegionPrices({
       packageName: 'com.foxdebug.acode',
       requestBody: {
-        price: { currencyCode: 'INR', units: '100', nanos: 0 },
+        price: {
+          currencyCode: 'INR',
+          units: String(Math.floor(price)),
+          nanos: Math.round((price % 1) * 1000000000),
+        },
       },
     });
-    return res.data.regionVersion.version;
+    return {
+      version: res.data.regionVersion.version,
+      regionPrices: res.data.convertedRegionPrices || {},
+    };
   } catch (_) {
-    return '2025/05';
+    console.warn(`  convertRegionPrices failed for INR ${price}, falling back to India-only pricing`);
+    return { version: '2025/05', regionPrices: {} };
   }
 }
 
-async function upsertOneTimeProduct(plugin, sku, packageName, regionsVersion) {
+async function deleteLegacyProduct(packageName, sku) {
+  try {
+    await androidpublisher.inappproducts.get({ packageName, sku });
+    await androidpublisher.inappproducts.delete({ packageName, sku });
+    return true;
+  } catch (err) {
+    if (err.code === 404) return false;
+    console.warn(`  Legacy product check/delete failed (${packageName}/${sku}): ${err.message}`);
+    return false;
+  }
+}
+
+async function upsertOneTimeProduct(plugin, sku, packageName, regionPricing) {
   let existingOptions = [];
+  let isNew = false;
   try {
     const { data } = await androidpublisher.monetization.onetimeproducts.get({
       packageName,
@@ -60,35 +85,69 @@ async function upsertOneTimeProduct(plugin, sku, packageName, regionsVersion) {
     existingOptions = data.purchaseOptions || [];
   } catch (err) {
     if (err.code !== 404) throw err;
+    isNew = true;
   }
 
-  const ourOption = {
-    purchaseOptionId: 'default',
-    buyOption: {},
-    regionalPricingAndAvailabilityConfigs: [
-      {
-        regionCode: 'IN',
-        availability: 'AVAILABLE',
-        price: {
-          currencyCode: 'INR',
-          units: String(Math.floor(plugin.price)),
-          nanos: Math.round((plugin.price % 1) * 1000000000),
-        },
+  if (isNew) {
+    await deleteLegacyProduct(packageName, sku);
+  }
+
+  const newConfigs = Object.entries(regionPricing.regionPrices).map(([regionCode, region]) => {
+    const units = region.price.units || 0;
+    const nanos = region.price.nanos || 0;
+    return {
+      regionCode,
+      availability: 'AVAILABLE',
+      price: {
+        currencyCode: region.price.currencyCode,
+        units: String(units === 0 && nanos === 0 ? 1 : units),
+        nanos: units === 0 && nanos === 0 ? 0 : nanos,
       },
-    ],
-  };
+    };
+  });
 
-  const existingIds = new Set(existingOptions.map((po) => po.purchaseOptionId));
-  const purchaseOptions = existingIds.has('default')
-    ? existingOptions.map((po) => (po.purchaseOptionId === 'default' ? ourOption : po))
-    : [...existingOptions, ourOption];
+  if (!newConfigs.length) {
+    newConfigs.push({
+      regionCode: 'IN',
+      availability: 'AVAILABLE',
+      price: {
+        currencyCode: 'INR',
+        units: String(Math.floor(plugin.price)),
+        nanos: Math.round((plugin.price % 1) * 1000000000),
+      },
+    });
+  }
 
-  return androidpublisher.monetization.onetimeproducts.patch({
+  let purchaseOptions;
+  if (existingOptions.length > 0) {
+    const newConfigMap = new Map(newConfigs.map((c) => [c.regionCode, c]));
+    purchaseOptions = existingOptions.map((po) => {
+      const oldConfigs = po.regionalPricingAndAvailabilityConfigs || [];
+      const mergedMap = new Map(oldConfigs.map((c) => [c.regionCode, c]));
+      for (const [code, config] of newConfigMap) {
+        mergedMap.set(code, config);
+      }
+      return {
+        ...po,
+        regionalPricingAndAvailabilityConfigs: Array.from(mergedMap.values()),
+      };
+    });
+  } else {
+    purchaseOptions = [
+      {
+        purchaseOptionId: 'default',
+        buyOption: {},
+        regionalPricingAndAvailabilityConfigs: newConfigs,
+      },
+    ];
+  }
+
+  await androidpublisher.monetization.onetimeproducts.patch({
     packageName,
     productId: sku,
     allowMissing: true,
     updateMask: 'listings,purchaseOptions',
-    'regionsVersion.version': regionsVersion,
+    'regionsVersion.version': regionPricing.version,
     requestBody: {
       packageName,
       productId: sku,
@@ -102,15 +161,34 @@ async function upsertOneTimeProduct(plugin, sku, packageName, regionsVersion) {
       ],
     },
   });
+
+  try {
+    await androidpublisher.monetization.onetimeproducts.purchaseOptions.batchUpdateStates({
+      packageName,
+      productId: sku,
+      requestBody: {
+        requests: purchaseOptions.map((po) => ({
+          activatePurchaseOptionRequest: {
+            packageName,
+            productId: sku,
+            purchaseOptionId: po.purchaseOptionId,
+          },
+        })),
+      },
+    });
+  } catch (err) {
+    console.warn(`  Activate purchase options failed for ${packageName}/${sku}: ${err.message}`);
+  }
 }
 
-async function syncPluginPrice(plugin, regionsVersion) {
+async function syncPluginPrice(plugin) {
   const sku = getPluginSKU(plugin.id);
+  const regionPricing = await getRegionPricing(plugin.price);
   const result = { id: plugin.id, name: plugin.name, price: plugin.price, packages: {} };
 
   for (const packageName of PACKAGE_NAMES) {
     try {
-      await upsertOneTimeProduct(plugin, sku, packageName, regionsVersion);
+      await upsertOneTimeProduct(plugin, sku, packageName, regionPricing);
       result.packages[packageName] = 'OK';
     } catch (error) {
       result.packages[packageName] = `FAILED: ${flattenErrors(error).join('; ') || error.message}`;
@@ -127,11 +205,21 @@ async function main() {
   await authenticate();
   console.log('Authenticated with Google Play API\n');
 
-  const regionsVersion = await getRegionsVersion();
-  console.log(`Regions version: ${regionsVersion}\n`);
-
   const plugins = getPaidPlugins();
-  console.log(`Found ${plugins.length} paid plugin(s)\n`);
+  const targetSku = process.argv.includes('--sku') ? process.argv[process.argv.indexOf('--sku') + 1] : null;
+
+  if (targetSku) {
+    const filtered = plugins.filter((p) => getPluginSKU(p.id) === targetSku);
+    if (filtered.length === 0) {
+      console.log(`No paid plugin found with SKU "${targetSku}".`);
+      return;
+    }
+    console.log(`Filtered to SKU "${targetSku}": ${filtered.length} plugin(s)`);
+    plugins.length = 0;
+    plugins.push(...filtered);
+  }
+
+  console.log(`Syncing ${plugins.length} paid plugin(s)\n`);
 
   if (plugins.length === 0) {
     console.log('No paid plugins to sync.');
@@ -141,11 +229,15 @@ async function main() {
   const results = [];
   for (const plugin of plugins) {
     console.log(`Syncing "${plugin.name}" (${plugin.id}): INR ${plugin.price}`);
-    const result = await syncPluginPrice(plugin, regionsVersion);
+    const result = await syncPluginPrice(plugin);
     results.push(result);
     const statuses = Object.values(result.packages);
     const allOk = statuses.every((s) => s.startsWith('OK'));
     console.log(`  ${allOk ? 'OK' : 'HAD ERRORS'}\n`);
+
+    if (plugins.length > 1) {
+      await sleep(500);
+    }
   }
 
   console.log('---');

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -1005,7 +1005,7 @@ async function registerSKU(name, id, price) {
       }
 
       const newConfigs = Object.entries(regionPricing.regionPrices).map(([regionCode, region]) => {
-        const units = region.price.units || 0;
+        const units = Number(region.price.units) || 0;
         const nanos = region.price.nanos || 0;
         return {
           regionCode,

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -942,20 +942,27 @@ function validatePlugin(json, icon, readmeFile) {
  */
 let cachedRegionsVersion = null;
 
-async function getRegionsVersion() {
-  if (cachedRegionsVersion) return cachedRegionsVersion;
-
+async function getRegionPricing(price) {
   try {
     const res = await androidpublisher.monetization.convertRegionPrices({
       packageName: 'com.foxdebug.acode',
       requestBody: {
-        price: { currencyCode: 'INR', units: '100', nanos: 0 },
+        price: {
+          currencyCode: 'INR',
+          units: String(Math.floor(price)),
+          nanos: Math.round((price % 1) * 1000000000),
+        },
       },
     });
     cachedRegionsVersion = res.data.regionVersion.version;
-    return cachedRegionsVersion;
+    return {
+      version: res.data.regionVersion.version,
+      regionPrices: res.data.convertedRegionPrices || {},
+    };
   } catch (_) {
-    return '2025/05';
+    if (!cachedRegionsVersion) cachedRegionsVersion = '2025/05';
+    console.warn(`convertRegionPrices failed for INR ${price}, falling back to cached region version`);
+    return { version: cachedRegionsVersion, regionPrices: {} };
   }
 }
 
@@ -965,7 +972,7 @@ async function registerSKU(name, id, price) {
     throw new Error('Invalid price');
   }
 
-  const regionsVersion = await getRegionsVersion();
+  const regionPricing = await getRegionPricing(price);
   const errors = [];
 
   await register('com.foxdebug.acode');
@@ -973,8 +980,8 @@ async function registerSKU(name, id, price) {
 
   async function register(packageName) {
     try {
-      // Fetch existing purchase options to preserve them in the PATCH
       let existingOptions = [];
+      let isNew = false;
       try {
         const { data } = await androidpublisher.monetization.onetimeproducts.get({
           packageName,
@@ -983,35 +990,76 @@ async function registerSKU(name, id, price) {
         existingOptions = data.purchaseOptions || [];
       } catch (err) {
         if (err.code !== 404) throw err;
+        isNew = true;
       }
 
-      const ourOption = {
-        purchaseOptionId: 'default',
-        buyOption: {},
-        regionalPricingAndAvailabilityConfigs: [
-          {
-            regionCode: 'IN',
-            availability: 'AVAILABLE',
-            price: {
-              currencyCode: 'INR',
-              units: String(Math.floor(price)),
-              nanos: Math.round((price % 1) * 1000000000),
-            },
-          },
-        ],
-      };
+      if (isNew) {
+        try {
+          await androidpublisher.inappproducts.get({ packageName, sku });
+          await androidpublisher.inappproducts.delete({ packageName, sku });
+        } catch (err) {
+          if (err.code !== 404) {
+            console.warn(`Legacy product check/delete failed for ${packageName}/${sku}:`, err.message);
+          }
+        }
+      }
 
-      const existingIds = new Set(existingOptions.map((po) => po.purchaseOptionId));
-      const purchaseOptions = existingIds.has('default')
-        ? existingOptions.map((po) => (po.purchaseOptionId === 'default' ? ourOption : po))
-        : [...existingOptions, ourOption];
+      const newConfigs = Object.entries(regionPricing.regionPrices).map(([regionCode, region]) => {
+        const units = region.price.units || 0;
+        const nanos = region.price.nanos || 0;
+        return {
+          regionCode,
+          availability: 'AVAILABLE',
+          price: {
+            currencyCode: region.price.currencyCode,
+            units: String(units === 0 && nanos === 0 ? 1 : units),
+            nanos: units === 0 && nanos === 0 ? 0 : nanos,
+          },
+        };
+      });
+
+      if (!newConfigs.length) {
+        newConfigs.push({
+          regionCode: 'IN',
+          availability: 'AVAILABLE',
+          price: {
+            currencyCode: 'INR',
+            units: String(Math.floor(price)),
+            nanos: Math.round((price % 1) * 1000000000),
+          },
+        });
+      }
+
+      let purchaseOptions;
+      if (existingOptions.length > 0) {
+        const newConfigMap = new Map(newConfigs.map((c) => [c.regionCode, c]));
+        purchaseOptions = existingOptions.map((po) => {
+          const oldConfigs = po.regionalPricingAndAvailabilityConfigs || [];
+          const mergedMap = new Map(oldConfigs.map((c) => [c.regionCode, c]));
+          for (const [code, config] of newConfigMap) {
+            mergedMap.set(code, config);
+          }
+          return {
+            ...po,
+            regionalPricingAndAvailabilityConfigs: Array.from(mergedMap.values()),
+          };
+        });
+      } else {
+        purchaseOptions = [
+          {
+            purchaseOptionId: 'default',
+            buyOption: {},
+            regionalPricingAndAvailabilityConfigs: newConfigs,
+          },
+        ];
+      }
 
       await androidpublisher.monetization.onetimeproducts.patch({
         packageName,
         productId: sku,
         allowMissing: true,
         updateMask: 'listings,purchaseOptions',
-        'regionsVersion.version': regionsVersion,
+        'regionsVersion.version': regionPricing.version,
         requestBody: {
           packageName,
           productId: sku,
@@ -1025,6 +1073,24 @@ async function registerSKU(name, id, price) {
           ],
         },
       });
+
+      try {
+        await androidpublisher.monetization.onetimeproducts.purchaseOptions.batchUpdateStates({
+          packageName,
+          productId: sku,
+          requestBody: {
+            requests: purchaseOptions.map((po) => ({
+              activatePurchaseOptionRequest: {
+                packageName,
+                productId: sku,
+                purchaseOptionId: po.purchaseOptionId,
+              },
+            })),
+          },
+        });
+      } catch (err) {
+        console.warn(`Activate purchase options failed for ${packageName}/${sku}: ${err.message}`);
+      }
     } catch (error) {
       const details = error.errors?.map(({ message: msg }) => msg).join('\n') || error.message;
       console.error(`Failed to register SKU for ${packageName}: ${details}`, error);

--- a/tests/integration/sku-lifecycle.test.js
+++ b/tests/integration/sku-lifecycle.test.js
@@ -55,7 +55,116 @@ describe('registerSKU on both packages', () => {
       });
       expect(res.data.listings[0].title).toBe(originalName);
     }
-  }, 15000);
+  }, 30000);
+
+  it('sets worldwide regional pricing, not just India', async () => {
+    const errors = await registerSKU(plugin.name, plugin.id, 50);
+    expect(errors).toHaveLength(0);
+
+    const sku = getPluginSKU(plugin.id);
+    for (const pkg of PACKAGES) {
+      const res = await androidpublisher.monetization.onetimeproducts.get({
+        packageName: pkg,
+        productId: sku,
+      });
+      const purchaseOptions = res.data.purchaseOptions || [];
+      expect(purchaseOptions.length).toBeGreaterThan(0);
+
+      for (const po of purchaseOptions) {
+        const configs = po.regionalPricingAndAvailabilityConfigs || [];
+        expect(configs.length).toBeGreaterThan(1);
+        const codes = configs.map((c) => c.regionCode);
+        expect(codes).toContain('IN');
+        expect(codes).toContain('US');
+        for (const c of configs) {
+          expect(c.availability).toBe('AVAILABLE');
+          expect(c.price).toBeDefined();
+          expect(c.price.currencyCode).toBeTruthy();
+        }
+      }
+    }
+  }, 30000);
+
+  it('preserves existing regions when updating price', async () => {
+    const sku = getPluginSKU(plugin.id);
+
+    for (const pkg of PACKAGES) {
+      const before = await androidpublisher.monetization.onetimeproducts.get({
+        packageName: pkg,
+        productId: sku,
+      });
+      const beforeCodes = new Set();
+      for (const po of before.data.purchaseOptions || []) {
+        for (const c of po.regionalPricingAndAvailabilityConfigs || []) {
+          beforeCodes.add(c.regionCode);
+        }
+      }
+
+      const errors = await registerSKU(plugin.name, plugin.id, 50);
+      expect(errors).toHaveLength(0);
+
+      const after = await androidpublisher.monetization.onetimeproducts.get({
+        packageName: pkg,
+        productId: sku,
+      });
+      const afterCodes = new Set();
+      for (const po of after.data.purchaseOptions || []) {
+        for (const c of po.regionalPricingAndAvailabilityConfigs || []) {
+          afterCodes.add(c.regionCode);
+        }
+      }
+
+      for (const code of beforeCodes) {
+        expect(afterCodes.has(code)).toBe(true);
+      }
+    }
+  }, 30000);
+
+  it('activates purchase options after creating product', async () => {
+    const errors = await registerSKU(plugin.name, plugin.id, 50);
+    expect(errors).toHaveLength(0);
+
+    const sku = getPluginSKU(plugin.id);
+    for (const pkg of PACKAGES) {
+      const res = await androidpublisher.monetization.onetimeproducts.get({
+        packageName: pkg,
+        productId: sku,
+      });
+      const purchaseOptions = res.data.purchaseOptions || [];
+      expect(purchaseOptions.length).toBeGreaterThan(0);
+
+      for (const po of purchaseOptions) {
+        expect(po.purchaseOptionId).toBeTruthy();
+        expect(po.regionalPricingAndAvailabilityConfigs).toBeDefined();
+        expect(po.regionalPricingAndAvailabilityConfigs.length).toBeGreaterThan(0);
+
+        for (const c of po.regionalPricingAndAvailabilityConfigs) {
+          expect(c.availability).toBe('AVAILABLE');
+        }
+      }
+    }
+  }, 30000);
+
+  it('sets minimum price of 1 unit for zero-conversion regions', async () => {
+    const errors = await registerSKU(plugin.name, plugin.id, 15);
+    expect(errors).toHaveLength(0);
+
+    const sku = getPluginSKU(plugin.id);
+    for (const pkg of PACKAGES) {
+      const res = await androidpublisher.monetization.onetimeproducts.get({
+        packageName: pkg,
+        productId: sku,
+      });
+      const purchaseOptions = res.data.purchaseOptions || [];
+
+      for (const po of purchaseOptions) {
+        for (const c of po.regionalPricingAndAvailabilityConfigs || []) {
+          const zeroPrice = parseInt(c.price.units, 10) === 0 && c.price.nanos === 0;
+          expect(zeroPrice).toBe(false);
+        }
+      }
+    }
+  }, 30000);
 
   it('throws for invalid price below MIN_PRICE', async () => {
     await expect(registerSKU('Test', 'test.id', 5)).rejects.toThrow('Invalid price');


### PR DESCRIPTION
…onal pricing

- Replace single-region (IN) pricing with multi-region pricing from Google Play convertRegionPrices API for one-time products
- Delete legacy inappproducts (v2) before creating one-time products (v3)
- Activate purchase options via batchUpdateStates after creation/update
- Fall back to India-only pricing when convertRegionPrices fails
- Guard against zero-price regions with minimum 1-unit fallback
- Add --sku filter to sync script for targeted syncs
- Add rate-limiting sleep between multi-plugin sync runs
- Add integration tests for worldwide pricing, region preservation, activation, and zero-price handling
- Bump CI Node.js to v24.16.0