### PR TITLE
feat: add status_text column, unify plugin status to integer represen…

### DIFF
--- a/client/components/pluginStatus.js
+++ b/client/components/pluginStatus.js
@@ -70,8 +70,9 @@ async function changePluginStatus(e) {
 
     const pluginRes = await fetch(`/api/plugin/${id}`);
     const pluginData = await pluginRes.json();
+    const prefix = target.className.split(' ')[0];
     target.textContent = capitalize(pluginData.status_text);
-    target.className = pluginData.status_text;
+    target.className = `${prefix} ${pluginData.status_text}`;
   } catch (error) {
     alert('Error', error.message);
   } finally {

--- a/client/components/pluginStatus.js
+++ b/client/components/pluginStatus.js
@@ -70,8 +70,8 @@ async function changePluginStatus(e) {
 
     const pluginRes = await fetch(`/api/plugin/${id}`);
     const pluginData = await pluginRes.json();
-    target.textContent = capitalize(pluginData.status);
-    target.className = pluginData.status;
+    target.textContent = capitalize(pluginData.status_text);
+    target.className = pluginData.status_text;
   } catch (error) {
     alert('Error', error.message);
   } finally {

--- a/client/components/plugins/index.js
+++ b/client/components/plugins/index.js
@@ -73,7 +73,7 @@ function Plugin({
   name,
   price,
   owned,
-  status,
+  status_text,
   userId,
   version,
   isAdmin,
@@ -108,7 +108,7 @@ function Plugin({
           <div title='Downloads counter'>
             {downloads.toLocaleString()} <span className='icon download' />
           </div>
-          <PluginStatus status={status} id={id} />
+          <PluginStatus status={status_text} id={id} />
           <div>{calcRating(upVotes, downVotes)}</div>
           {comments > 0 && (
             <div>

--- a/client/pages/plugin/index.js
+++ b/client/pages/plugin/index.js
@@ -39,7 +39,7 @@ export default async function Plugin({ id: pluginId, section = 'description', ca
     id,
     name,
     price,
-    status,
+    status_text,
     author,
     version,
     license,
@@ -102,7 +102,7 @@ export default async function Plugin({ id: pluginId, section = 'description', ca
     }
   }
 
-  if (user?.isAdmin && plugin.status !== 'approved') {
+  if (user?.isAdmin && plugin.status_text !== 'approved') {
     canInstall = false;
   }
 
@@ -269,7 +269,7 @@ export default async function Plugin({ id: pluginId, section = 'description', ca
               <span className='icon download' /> Install
             </button>
           )}
-          <PluginStatus status={status} id={id} style='button' />
+          <PluginStatus status={status_text} id={id} style='button' />
         </div>
         <div className='info-container'>
           <div className='info'>

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -262,7 +262,7 @@ router.get('{/:pluginId}', async (req, res) => {
       if (!loggedInUser) {
         where.push([Plugin.STATUS, Plugin.STATUS_APPROVED]);
       } else if (loggedInUser.id === userId && !loggedInUser.isAdmin) {
-        where.push([Plugin.STATUS, Plugin.STATUS_INACTIVE, '<>']);
+        where.push([Plugin.STATUS, Plugin.STATUS_DELETED, '<>']);
       } else if (!loggedInUser.isAdmin) {
         where.push([Plugin.STATUS, Plugin.STATUS_APPROVED]);
       }
@@ -368,7 +368,7 @@ router.get('{/:pluginId}', async (req, res) => {
 
       const isOwner = loggedInUser && loggedInUser.id === row.user_id;
 
-      if (row.status === Plugin.STATUS_INACTIVE && !loggedInUser?.isAdmin) {
+      if (row.status === Plugin.STATUS_DELETED && !loggedInUser?.isAdmin) {
         res.status(404).send({ error: 'Not found' });
         return;
       }

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -250,21 +250,23 @@ router.get('{/:pluginId}', async (req, res) => {
       columns.push(Plugin.AUTHOR_EMAIL);
       columns.push(Plugin.AUTHOR_GITHUB);
       columns.push(Plugin.AUTHOR_GITHUB);
-    }
-
-    if (loggedInUser && (loggedInUser.isAdmin || loggedInUser.id === userId)) {
       columns.push(Plugin.STATUS);
-    }
-
-    if (!loggedInUser) {
-      where.push([Plugin.STATUS, Plugin.STATUS_APPROVED]);
-    } else if (loggedInUser.id === userId && !loggedInUser.isAdmin) {
-      where.push([Plugin.STATUS, Plugin.STATUS_INACTIVE, '<>']);
-    }
-
-    if (pluginId) {
+      columns.push(Plugin.STATUS_TEXT);
       where.push([Plugin.ID, pluginId]);
     } else {
+      if (loggedInUser && (loggedInUser.isAdmin || loggedInUser.id === userId)) {
+        columns.push(Plugin.STATUS);
+        columns.push(Plugin.STATUS_TEXT);
+      }
+
+      if (!loggedInUser) {
+        where.push([Plugin.STATUS, Plugin.STATUS_APPROVED]);
+      } else if (loggedInUser.id === userId && !loggedInUser.isAdmin) {
+        where.push([Plugin.STATUS, Plugin.STATUS_INACTIVE, '<>']);
+      } else if (!loggedInUser.isAdmin) {
+        where.push([Plugin.STATUS, Plugin.STATUS_APPROVED]);
+      }
+
       if (userId) {
         where.push([Plugin.USER_ID, userId]);
       }
@@ -362,6 +364,23 @@ router.get('{/:pluginId}', async (req, res) => {
       if (!row) {
         res.status(404).send({ error: 'Not found' });
         return;
+      }
+
+      const isOwner = loggedInUser && loggedInUser.id === row.user_id;
+
+      if (row.status === Plugin.STATUS_INACTIVE && !loggedInUser?.isAdmin) {
+        res.status(404).send({ error: 'Not found' });
+        return;
+      }
+
+      if (row.status !== Plugin.STATUS_APPROVED && !loggedInUser?.isAdmin && !isOwner) {
+        res.status(404).send({ error: 'Not found' });
+        return;
+      }
+
+      if (!loggedInUser?.isAdmin && !isOwner) {
+        row.status = undefined;
+        row.status_text = undefined;
       }
 
       res.send(row);

--- a/server/apis/razorpay.js
+++ b/server/apis/razorpay.js
@@ -63,7 +63,7 @@ router.post('/create-order', async (req, res) => {
       return;
     }
 
-    if (plugin[Plugin.STATUS] !== 'approved') {
+    if (plugin[Plugin.STATUS] !== Plugin.STATUS_APPROVED) {
       res.status(400).send({ error: 'You can not buy this plugin, please try again later' });
       return;
     }

--- a/server/entities/plugin.js
+++ b/server/entities/plugin.js
@@ -51,6 +51,7 @@ class Plugin extends Entity {
   ICON = 'icon';
   PRICE = 'price';
   STATUS = 'status';
+  STATUS_TEXT = 'status_text';
   AUTHOR = 'author';
   VERSION = 'version';
   USER_ID = 'user_id';
@@ -201,7 +202,7 @@ class Plugin extends Entity {
   }
 
   get allColumns() {
-    return [...this.minColumns, this.STATUS];
+    return [...this.minColumns, this.STATUS, this.STATUS_TEXT];
   }
 
   get #initialColumns() {
@@ -228,7 +229,8 @@ class Plugin extends Entity {
       this.STATUS_CHANGE_DATE,
       this.PACKAGE_UPDATED_AT,
       this.STATUS_CHANGE_MESSAGE,
-      "CASE WHEN status = 0 THEN 'pending' WHEN status = 1 THEN 'approved' WHEN status = 2 THEN 'rejected' WHEN status = 3 THEN 'deleted' END as status",
+      this.STATUS,
+      "CASE WHEN status = 0 THEN 'pending' WHEN status = 1 THEN 'approved' WHEN status = 2 THEN 'rejected' WHEN status = 3 THEN 'deleted' END as status_text",
       `'${process.env.HOST}/plugin-icon/' || id as icon`,
     ];
   }
@@ -248,6 +250,7 @@ class Plugin extends Entity {
       'p.created_at as created_at',
       'p.updated_at as updated_at',
       'p.status as status',
+      'p.status_text as status_text',
       'p.supported_editor as supported_editor',
       'p.min_version_code as min_version_code',
       'p.repository as repository',

--- a/server/entities/plugin.js
+++ b/server/entities/plugin.js
@@ -81,7 +81,7 @@ class Plugin extends Entity {
   STATUS_PENDING = 0;
   STATUS_APPROVED = 1;
   STATUS_REJECTED = 2;
-  STATUS_INACTIVE = 3;
+  STATUS_DELETED = 3;
 
   EDITOR_ACE = 'ace';
   EDITOR_CM = 'cm';
@@ -141,7 +141,7 @@ class Plugin extends Entity {
    * @param {'AND' | 'OR'} operator when there are multiple where clauses
    */
   delete(where, operator = 'AND') {
-    return this.update([this.STATUS, this.STATUS_INACTIVE], where, operator);
+    return this.update([this.STATUS, this.STATUS_DELETED], where, operator);
   }
 
   async deletePermanently(where, operator = 'AND') {

--- a/server/main.js
+++ b/server/main.js
@@ -10,17 +10,8 @@ const Handlebars = require('handlebars');
 const markdownToText = require('markdown-to-txt');
 const defaultOg = require('./defaultOg.json');
 const { getMetadata, getPluginsMetadata, getFaqsMetadata, FALLBACK_TITLE } = require('./routeMetadata');
-
-/**
- * Escape JSON-LD string for safe embedding inside a <script> tag.
- * Prevents </script> and similar sequences in schema text from
- * prematurely terminating the JSON-LD script tag.
- */
-function safeSchema(jsonString) {
-  if (!jsonString) return null;
-  return jsonString.replace(/<\//g, '<\\/');
-}
 const Plugin = require('./entities/plugin');
+const { getLoggedInUser } = require('./lib/helpers');
 const apis = require('./routes/apis');
 const oauth = require('./apis/oauth');
 const setAuth = require('./lib/gapis');
@@ -28,13 +19,13 @@ const migrationRunner = require('./lib/migrationRunner');
 
 const app = express();
 
-app.set('trust proxy', 1);
-
 const PORT = process.env.PORT || 3000;
 
 const ALLOWED_ORIGINS = new Set(['https://localhost', 'https://acode.app']);
 
 async function main() {
+  app.set('trust proxy', 1);
+
   await setAuth();
 
   app.use((_req, res, next) => {
@@ -227,6 +218,19 @@ async function main() {
         return;
       }
 
+      const loggedInUser = await getLoggedInUser(req);
+      const isOwner = loggedInUser && loggedInUser.id === plugin.user_id;
+
+      if (plugin.status === Plugin.STATUS_INACTIVE && !loggedInUser?.isAdmin) {
+        next();
+        return;
+      }
+
+      if (plugin.status !== Plugin.STATUS_APPROVED && !loggedInUser?.isAdmin && !isOwner) {
+        next();
+        return;
+      }
+
       const template = path.resolve(__dirname, './index.hbs');
       const source = fs.readFileSync(template, 'utf8');
       const templateScript = Handlebars.compile(source);
@@ -406,6 +410,16 @@ async function start() {
   app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
   });
+}
+
+/**
+ * Escape JSON-LD string for safe embedding inside a <script> tag.
+ * Prevents </script> and similar sequences in schema text from
+ * prematurely terminating the JSON-LD script tag.
+ */
+function safeSchema(jsonString) {
+  if (!jsonString) return null;
+  return jsonString.replace(/<\//g, '<\\/');
 }
 
 start();

--- a/server/main.js
+++ b/server/main.js
@@ -221,7 +221,7 @@ async function main() {
       const loggedInUser = await getLoggedInUser(req);
       const isOwner = loggedInUser && loggedInUser.id === plugin.user_id;
 
-      if (plugin.status === Plugin.STATUS_INACTIVE && !loggedInUser?.isAdmin) {
+      if (plugin.status === Plugin.STATUS_DELETED && !loggedInUser?.isAdmin) {
         next();
         return;
       }


### PR DESCRIPTION
…tation

- Add STATUS_TEXT column derived via CASE expression in entity layer, keeping raw integer `status` alongside string `status_text`
- Update all client-side code to use `status_text` for rendering (pluginStatus.js, plugins/index.js, pages/plugin/index.js)
- Add authorization checks in API and SSR routes:
  - Hide inactive plugins from non-admins (404)
  - Hide non-approved plugins from non-owners/non-admins (404)
  - Strip status/status_text from API response for unauthorized users
- Fix hardcoded string comparison in razorpay.js to use Plugin.STATUS_APPROVED constant
- Move safeSchema helper to module bottom and trust proxy inside main()