### PR TITLE
fix: clamp admin pagination and merge matching mode plugins

### DIFF
--- a/client/pages/admin/index.js
+++ b/client/pages/admin/index.js
@@ -50,9 +50,9 @@ export default async function Admin({ queries = {} }) {
 
 function Sponsors() {
   const currentPage = Reactive(1);
-  const totalPages = Reactive(-1);
+  const totalPages = Reactive(0);
   const limit = 10;
-  const ref = Ref(goTo.bind(null, 1));
+  const ref = Ref(() => goTo(1));
 
   return (
     <div className='sponsors'>
@@ -73,24 +73,17 @@ function Sponsors() {
         </table>
       </div>
       <div className='pagination'>
-        <button type='button' on:click={() => goTo(--currentPage.value)} title='previous page' className='icon navigate_before' /> {currentPage}/
-        {totalPages} <button type='button' on:click={() => goTo(++currentPage.value)} title='next page' className='icon navigate_next' />
+        <button type='button' onclick={() => goTo(currentPage.value - 1)} title='previous page' className='icon navigate_before' /> {currentPage}/
+        {totalPages} <button type='button' onclick={() => goTo(currentPage.value + 1)} title='next page' className='icon navigate_next' />
       </div>
     </div>
   );
 
   async function goTo(page) {
-    if (totalPages.value === 0) {
-      currentPage.value = 0;
-      return;
-    }
-
     if (page < 1) {
       page = 1;
-      currentPage.value = 1;
     } else if (totalPages.value > 0 && page > totalPages.value) {
-      currentPage.value = totalPages.value;
-      return;
+      page = totalPages.value;
     }
 
     const res = await fetch(`/api/admin/sponsors?page=${page}&limit=${limit}`);
@@ -103,9 +96,10 @@ function Sponsors() {
       ref.innerHTML = 'Failed to load sponsors';
       return;
     }
-    totalPages.value = pages || 0;
+    const pageCount = pages || 0;
+    totalPages.value = pageCount;
 
-    if (pages === 0) {
+    if (pageCount === 0) {
       currentPage.value = 0;
       ref.innerHTML = '';
       return;
@@ -377,11 +371,11 @@ function Plugins() {
         Loading...
       </small>
       <div className='pagination'>
-        <button ref={prevBtn} type='button' on:click={() => goTo(currentPage.value - 1)} title='Previous page' className='icon navigate_before' />
+        <button ref={prevBtn} type='button' onclick={() => goTo(currentPage.value - 1)} title='Previous page' className='icon navigate_before' />
         <span>
           {currentPage}/{totalPages}
         </span>
-        <button ref={nextBtn} type='button' on:click={() => goTo(currentPage.value + 1)} title='Next page' className='icon navigate_next' />
+        <button ref={nextBtn} type='button' onclick={() => goTo(currentPage.value + 1)} title='Next page' className='icon navigate_next' />
       </div>
     </div>
   );
@@ -885,10 +879,10 @@ function AppSettings() {
 }
 
 function Users() {
-  const currentPage = Reactive(0);
-  const totalPages = Reactive(1);
+  const currentPage = Reactive(1);
+  const totalPages = Reactive(0);
   const limit = 10;
-  const ref = Ref(goTo.bind(null, currentPage.value));
+  const ref = Ref(() => goTo(1));
   let debounceTimer;
   let name = '';
   let email = '';
@@ -925,8 +919,8 @@ function Users() {
         </table>
       </div>
       <div className='pagination'>
-        <button type='button' on:click={() => goTo(currentPage.value - 1)} title='previous page' className='icon navigate_before' /> {currentPage}/
-        {totalPages} <button type='button' on:click={() => goTo(currentPage.value + 1)} title='next page' className='icon navigate_next' />
+        <button type='button' onclick={() => goTo(currentPage.value - 1)} title='previous page' className='icon navigate_before' /> {currentPage}/
+        {totalPages} <button type='button' onclick={() => goTo(currentPage.value + 1)} title='next page' className='icon navigate_next' />
       </div>
     </div>
   );
@@ -939,26 +933,29 @@ function Users() {
   async function goTo(page) {
     if (page < 1) {
       page = 1;
-      currentPage.value = 1;
-    } else if (totalPages.value !== -1 && page > totalPages.value) {
+    } else if (totalPages.value > 0 && page > totalPages.value) {
       page = totalPages.value;
-      currentPage.value = totalPages.value;
-      return;
     }
 
     let apiUrl = `api/admin/users?page=${page}&limit=${limit}`;
 
     if (name) {
-      apiUrl += `&name=${name}`;
+      apiUrl += `&name=${encodeURIComponent(name)}`;
     }
     if (email) {
-      apiUrl += `&email=${email}`;
+      apiUrl += `&email=${encodeURIComponent(email)}`;
     }
 
     const res = await fetch(apiUrl);
     const { users, pages } = await res.json();
-    totalPages.value = pages;
+    const pageCount = pages || 0;
+    totalPages.value = pageCount;
+    currentPage.value = pageCount === 0 ? 0 : page;
     ref.innerHTML = '';
+    if (!Array.isArray(users) || users.length === 0) {
+      ref.innerHTML = '<tr><td colspan="5" class="empty-cell">No users found</td></tr>';
+      return;
+    }
     ref.append(
       ...users.map((user) => (
         <tr id={`user-${user.id}`}>
@@ -1359,11 +1356,11 @@ function Payments() {
         Loading...
       </small>
       <div className='pagination'>
-        <button ref={prevBtn} type='button' on:click={() => goTo(currentPage.value - 1)} title='Previous page' className='icon navigate_before' />
+        <button ref={prevBtn} type='button' onclick={() => goTo(currentPage.value - 1)} title='Previous page' className='icon navigate_before' />
         <span>
           {currentPage}/{totalPages}
         </span>
-        <button ref={nextBtn} type='button' on:click={() => goTo(currentPage.value + 1)} title='Next page' className='icon navigate_next' />
+        <button ref={nextBtn} type='button' onclick={() => goTo(currentPage.value + 1)} title='Next page' className='icon navigate_next' />
       </div>
     </div>
   );
@@ -1577,9 +1574,10 @@ function Modes() {
 
   const createFormRow = (modeItem = {}) => {
     const inputRef = Ref();
+    const regex = modeItem.regex || modeItem.mode || '';
     const row = (
       <div className='mode-form-row'>
-        <input type='text' placeholder='Mode (e.g. csv, python)' value={modeItem.mode || ''} className='mode-name' />
+        <input type='text' placeholder='Extension regex (e.g. ^(csv|tsv)$)' value={regex} className='mode-regex' />
         <input
           ref={inputRef}
           type='text'
@@ -1630,10 +1628,16 @@ function Modes() {
     const rows = listRef.el.querySelectorAll('.mode-form-row');
     const modes = [];
     for (const row of rows) {
-      const mode = row.querySelector('.mode-name').value.trim();
+      const regex = row.querySelector('.mode-regex').value.trim();
       const pluginIdsRaw = row.querySelector('.mode-plugins').value.trim();
-      if (!mode) {
-        alert('ERROR', 'Mode name is required for each entry');
+      if (!regex) {
+        alert('ERROR', 'Extension regex is required for each entry');
+        return;
+      }
+      try {
+        new RegExp(regex);
+      } catch (err) {
+        alert('ERROR', `Invalid regex "${regex}": ${err.message}`);
         return;
       }
       const pluginIds = pluginIdsRaw
@@ -1642,7 +1646,7 @@ function Modes() {
             .map((id) => id.trim())
             .filter(Boolean)
         : [];
-      modes.push({ mode, pluginIds });
+      modes.push({ regex, pluginIds });
     }
     try {
       const res = await fetch('/api/admin/modes', {

--- a/client/pages/admin/style.scss
+++ b/client/pages/admin/style.scss
@@ -283,6 +283,12 @@
       white-space: nowrap;
     }
 
+    th:first-child,
+    td:first-child {
+      width: 1%;
+      white-space: nowrap;
+    }
+
     tbody tr:hover {
       background-color: rgba(255, 255, 255, 0.03);
     }
@@ -688,7 +694,7 @@
           border-color: var(--primary-color);
         }
 
-        &.mode-name {
+        &.mode-regex {
           flex: 1;
           min-width: 120px;
         }

--- a/server/apis/admin.js
+++ b/server/apis/admin.js
@@ -175,8 +175,9 @@ router.get('/reports/:year/:month', async (req, res) => {
 });
 
 router.get('/users', async (req, res) => {
-  const { page, limit, name, email } = req.query;
-  const count = await User.count();
+  const { page = 1, limit = 10, name, email } = req.query;
+  const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+  const limitNum = Math.max(Math.min(parseInt(limit, 10) || 10, 100), 1);
   const where = [];
 
   if (name) {
@@ -186,13 +187,15 @@ router.get('/users', async (req, res) => {
     where.push([User.EMAIL, email, 'LIKE']);
   }
 
+  const count = await User.count(where);
   const users = await User.get(User.safeColumns, where, {
-    page,
-    limit,
+    page: pageNum,
+    limit: limitNum,
   });
   res.send({
-    pages: Math.ceil(count / limit),
+    pages: Math.ceil(count / limitNum),
     users,
+    total: count,
   });
 });
 
@@ -401,18 +404,30 @@ router.put('/modes', async (req, res) => {
       res.status(400).json({ error: 'modes must be an array' });
       return;
     }
+    const normalizedModes = [];
     for (const m of modes) {
-      if (!m.mode || !Array.isArray(m.pluginIds)) {
-        res.status(400).json({ error: 'Each mode must have mode (string) and pluginIds (array)' });
+      const regex = String(m.regex || m.mode || '').trim();
+      if (!regex || !Array.isArray(m.pluginIds)) {
+        res.status(400).json({ error: 'Each mode must have regex (string) and pluginIds (array)' });
         return;
       }
+      try {
+        new RegExp(regex);
+      } catch (err) {
+        res.status(400).json({ error: `Invalid regex "${regex}": ${err.message}` });
+        return;
+      }
+      normalizedModes.push({
+        regex,
+        pluginIds: [...new Set(m.pluginIds.map((id) => String(id).trim()).filter(Boolean))],
+      });
     }
-    const modeNames = modes.map((m) => m.mode);
-    if (new Set(modeNames).size !== modeNames.length) {
-      res.status(400).json({ error: 'Duplicate mode names are not allowed' });
+    const regexes = normalizedModes.map((m) => m.regex);
+    if (new Set(regexes).size !== regexes.length) {
+      res.status(400).json({ error: 'Duplicate mode regexes are not allowed' });
       return;
     }
-    const allIds = [...new Set(modes.flatMap((m) => m.pluginIds))];
+    const allIds = [...new Set(normalizedModes.flatMap((m) => m.pluginIds))];
     if (allIds.length) {
       const existing = await plugin.get([plugin.ID], [plugin.ID, allIds, 'IN']);
       const existingIds = new Set(existing.map((r) => String(r.id)));
@@ -423,9 +438,9 @@ router.put('/modes', async (req, res) => {
       }
     }
     const tmpFile = `${modePluginsFile}.tmp`;
-    await fs.writeFile(tmpFile, JSON.stringify({ modes }, null, 2));
+    await fs.writeFile(tmpFile, JSON.stringify({ modes: normalizedModes }, null, 2));
     await fs.rename(tmpFile, modePluginsFile);
-    res.json({ message: 'success', modes });
+    res.json({ message: 'success', modes: normalizedModes });
   } catch {
     res.status(500).json({ error: 'Failed to save mode plugins' });
   }

--- a/server/apis/admin.js
+++ b/server/apis/admin.js
@@ -15,6 +15,7 @@ const RazorpayOrder = require('../entities/razorpayOrder');
 const Sponsor = require('../entities/sponsor');
 const downloadSalesReportCsv = require('../lib/downloadSalesCsv');
 const sendEmail = require('../lib/sendEmail');
+const { validateModeRegex } = require('../lib/modeRegex');
 
 const router = Router();
 
@@ -411,10 +412,9 @@ router.put('/modes', async (req, res) => {
         res.status(400).json({ error: 'Each mode must have regex (string) and pluginIds (array)' });
         return;
       }
-      try {
-        new RegExp(regex);
-      } catch (err) {
-        res.status(400).json({ error: `Invalid regex "${regex}": ${err.message}` });
+      const regexValidation = validateModeRegex(regex);
+      if (!regexValidation.valid) {
+        res.status(400).json({ error: `Invalid regex "${regex}": ${regexValidation.error}` });
         return;
       }
       normalizedModes.push({

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -35,16 +35,57 @@ const validLicenses = [
   'Proprietary',
 ];
 
-/**
- * Score a mode entry against a search keyword.
- * Returns 0 for no match, higher = better.
- * Exact match > prefix match > substring match.
- */
-function matchScore(mode, keyword) {
+function legacyModeScore(mode, keyword) {
   if (mode === keyword) return 100;
   if (mode.startsWith(keyword)) return 80 - keyword.length;
   if (mode.includes(keyword)) return 50 + keyword.length;
   return 0;
+}
+
+/**
+ * Score a mode entry against a search keyword.
+ * Returns 0 for no match, higher = better.
+ * Supports the new regex field and keeps legacy mode strings working.
+ */
+function matchScore(entry, keyword) {
+  const normalizedKeyword = String(keyword || '')
+    .trim()
+    .toLowerCase();
+  if (!normalizedKeyword) return 0;
+  if (!entry.regex) return legacyModeScore(String(entry.mode || '').toLowerCase(), normalizedKeyword);
+
+  const pattern = entry.regex;
+  if (!pattern) return 0;
+
+  try {
+    const match = normalizedKeyword.match(new RegExp(pattern, 'i'));
+    if (!match) return 0;
+
+    const matchedText = match[0].toLowerCase();
+    const exact = matchedText === normalizedKeyword ? 10000 : 0;
+    const anchored = match.index === 0 ? 1000 : 0;
+    return exact + anchored + matchedText.length * 100 - match.index;
+  } catch {
+    return 0;
+  }
+}
+
+function getMatchingModeEntries(modes, keyword) {
+  return modes
+    .map((m, index) => ({ m, index, score: matchScore(m, keyword) }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map((s) => s.m);
+}
+
+function getModePluginIds(modes, keyword) {
+  const allIds = new Set();
+  for (const entry of getMatchingModeEntries(modes, keyword)) {
+    for (const id of entry.pluginIds || []) {
+      allIds.add(id);
+    }
+  }
+  return [...allIds];
 }
 
 router.get('/owned/:sku', async (req, res) => {
@@ -292,17 +333,7 @@ router.get('{/:pluginId}', async (req, res) => {
             const raw = await fs.promises.readFile(modeFile, 'utf8');
             const data = JSON.parse(raw);
             const modes = data.modes || [];
-            const scored = modes
-              .map((m) => ({ m, score: matchScore(m.mode.toLowerCase(), modeKeyword) }))
-              .filter((s) => s.score > 0)
-              .sort((a, b) => b.score - a.score);
-            const allIds = new Set();
-            for (const s of scored) {
-              for (const id of s.m.pluginIds || []) {
-                allIds.add(id);
-              }
-            }
-            modePluginIds = [...allIds];
+            modePluginIds = getModePluginIds(modes, modeKeyword);
           } catch (err) {
             if (err.code !== 'ENOENT') {
               console.error('Failed to read mode-plugins.json:', err.message);
@@ -1248,3 +1279,6 @@ function isVersionGreater(newV, oldV) {
 module.exports = router;
 module.exports.registerSKU = registerSKU;
 module.exports.isValidPrice = isValidPrice;
+module.exports.matchScore = matchScore;
+module.exports.getMatchingModeEntries = getMatchingModeEntries;
+module.exports.getModePluginIds = getModePluginIds;

--- a/server/apis/plugin.js
+++ b/server/apis/plugin.js
@@ -13,6 +13,7 @@ const { getLoggedInUser, getPluginSKU, detectUserCurrency, formatAmount } = requ
 const getRazorpay = require('../lib/razorpay');
 const sendEmail = require('../lib/sendEmail');
 const { convertPrice } = require('../lib/exchangeRates');
+const { isModeKeywordSafe, validateModeRegex } = require('../lib/modeRegex');
 
 const androidpublisher = google.androidpublisher('v3');
 
@@ -48,21 +49,20 @@ function legacyModeScore(mode, keyword) {
  * Supports the new regex field and keeps legacy mode strings working.
  */
 function matchScore(entry, keyword) {
-  const normalizedKeyword = String(keyword || '')
-    .trim()
-    .toLowerCase();
-  if (!normalizedKeyword) return 0;
-  if (!entry.regex) return legacyModeScore(String(entry.mode || '').toLowerCase(), normalizedKeyword);
+  const rawKeyword = String(keyword || '').trim();
+  if (!rawKeyword || !isModeKeywordSafe(rawKeyword)) return 0;
 
-  const pattern = entry.regex;
-  if (!pattern) return 0;
+  if (!entry.regex) return legacyModeScore(String(entry.mode || '').toLowerCase(), rawKeyword.toLowerCase());
+
+  const regexValidation = validateModeRegex(entry.regex);
+  if (!regexValidation.valid) return 0;
 
   try {
-    const match = normalizedKeyword.match(new RegExp(pattern, 'i'));
+    const match = rawKeyword.match(new RegExp(entry.regex));
     if (!match) return 0;
 
-    const matchedText = match[0].toLowerCase();
-    const exact = matchedText === normalizedKeyword ? 10000 : 0;
+    const matchedText = match[0];
+    const exact = matchedText === rawKeyword ? 10000 : 0;
     const anchored = match.index === 0 ? 1000 : 0;
     return exact + anchored + matchedText.length * 100 - match.index;
   } catch {
@@ -326,7 +326,7 @@ router.get('{/:pluginId}', async (req, res) => {
 
       if (name) {
         if (name.startsWith('mode:') && name.length > 5) {
-          const modeKeyword = name.slice(5).toLowerCase();
+          const modeKeyword = name.slice(5);
           const modeFile = path.resolve(__dirname, '../../data/mode-plugins.json');
           let modePluginIds = [];
           try {

--- a/server/lib/modeRegex.js
+++ b/server/lib/modeRegex.js
@@ -1,0 +1,55 @@
+const MAX_MODE_REGEX_LENGTH = 1024;
+const MAX_MODE_KEYWORD_LENGTH = 128;
+const GROUP_QUANTIFIER_REGEX = /\(([^()]*)\)\s*(?:[+*]|\{\d+(?:,\d*)?\})/g;
+const NESTED_QUANTIFIER_REGEX = /\((?:[^()\\]|\\.)*(?:[+*]|\{\d+(?:,\d*)?\})(?:[^()\\]|\\.)*\)\s*(?:[+*]|\{\d+(?:,\d*)?\})/;
+
+function validateModeRegex(pattern) {
+  if (typeof pattern !== 'string' || !pattern.trim()) {
+    return { valid: false, error: 'regex is required' };
+  }
+
+  if (pattern.length > MAX_MODE_REGEX_LENGTH) {
+    return { valid: false, error: `regex must be ${MAX_MODE_REGEX_LENGTH} characters or fewer` };
+  }
+
+  try {
+    new RegExp(pattern);
+  } catch (err) {
+    return { valid: false, error: err.message };
+  }
+
+  if (NESTED_QUANTIFIER_REGEX.test(pattern)) {
+    return { valid: false, error: 'regex contains nested quantifiers' };
+  }
+
+  for (const match of pattern.matchAll(GROUP_QUANTIFIER_REGEX)) {
+    const alternatives = match[1].split('|');
+    if (alternatives.length < 2) continue;
+
+    const uniqueAlternatives = new Set(alternatives);
+    if (uniqueAlternatives.size !== alternatives.length) {
+      return { valid: false, error: 'regex contains ambiguous repeated alternatives' };
+    }
+
+    for (const a of alternatives) {
+      for (const b of alternatives) {
+        if (a && b && a !== b && b.startsWith(a)) {
+          return { valid: false, error: 'regex contains ambiguous repeated alternatives' };
+        }
+      }
+    }
+  }
+
+  return { valid: true };
+}
+
+function isModeKeywordSafe(keyword) {
+  return String(keyword || '').trim().length <= MAX_MODE_KEYWORD_LENGTH;
+}
+
+module.exports = {
+  MAX_MODE_KEYWORD_LENGTH,
+  MAX_MODE_REGEX_LENGTH,
+  isModeKeywordSafe,
+  validateModeRegex,
+};

--- a/server/lib/sendEmail.js
+++ b/server/lib/sendEmail.js
@@ -24,15 +24,31 @@ async function sendEmail(email, name, subject, message) {
     from: '"Acode - Foxbiz" <noreply@acode.app>',
     to: email,
     subject,
-    html: `<div style="font-family: Helvetica,Arial,sans-serif;overflow:auto;line-height:2">
-    <h1 style="border-bottom:1px solid #eee">
-      <a href="https://acode.app" style="font-size:1.4em;color: #00466a;text-decoration:none;font-weight:600">Acode by Foxbiz Software Pvt. Ltd.</a>
-    </h1>
-    <p style="font-size:1.1em">Hi ${name},</p>
-    <p>${message}</p>
-    <p>Regards,<br />Acode by Foxbiz</p>
-    <small>This is an auto-generated email. Please do not reply.</small>
-  </div>`,
+    html: `<div style="background-color:#f1f5f9;padding:40px 20px">
+  <div style="max-width:560px;margin:0 auto;background:#ffffff;border-radius:8px;overflow:hidden">
+    <div style="padding:32px 40px 0 40px">
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif">
+        <div style="font-size:20px;font-weight:600;color:#334155;line-height:1.3">Acode</div>
+      </div>
+      <div style="height:1px;background:#f1f5f9;margin:24px 0"></div>
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;color:#1e293b;line-height:1.7">
+        Hi ${name},
+      </div>
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:15px;color:#475569;line-height:1.7;padding-top:12px">
+        ${message}
+      </div>
+      <div style="height:1px;background:#f1f5f9;margin-top:28px"></div>
+    </div>
+    <div style="padding:20px 40px 32px 40px">
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#94a3b8;line-height:1.5">
+        Acode by <strong>Foxbiz Software Pvt. Ltd.</strong>
+      </div>
+      <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;color:#cbd5e1;line-height:1.5;margin-top:4px">
+        This is an auto-generated email. Please do not reply.
+      </div>
+    </div>
+  </div>
+</div>`,
   };
 
   if (process.env.NODE_ENV === 'development') {

--- a/tests/unit/plugin-schema.test.js
+++ b/tests/unit/plugin-schema.test.js
@@ -1,6 +1,7 @@
 const path = require('node:path');
 const fs = require('node:fs');
 const { getMatchingModeEntries, getModePluginIds, isValidPrice, matchScore } = require('../../server/apis/plugin');
+const { validateModeRegex } = require('../../server/lib/modeRegex');
 
 describe('plugin schema', () => {
   it('price field has correct bounds', () => {
@@ -39,9 +40,17 @@ describe('mode plugin matching', () => {
   });
 
   it('keeps legacy mode strings working', () => {
+    expect(matchScore({ mode: 'csv' }, 'CSV')).toBeGreaterThan(0);
     expect(matchScore({ mode: 'csv' }, 'csv')).toBeGreaterThan(0);
     expect(matchScore({ mode: 'csv' }, 'json')).toBe(0);
     expect(matchScore({ mode: 'c' }, 'csv')).toBe(0);
+  });
+
+  it('respects case-sensitive regex patterns', () => {
+    const entry = { regex: '^[A-Z]{2}$', pluginIds: ['uppercase.plugin'] };
+
+    expect(matchScore(entry, 'JS')).toBeGreaterThan(0);
+    expect(matchScore(entry, 'js')).toBe(0);
   });
 
   it('orders matching mode entries by score', () => {
@@ -60,5 +69,22 @@ describe('mode plugin matching', () => {
     ];
 
     expect(getModePluginIds(modes, 'csv')).toEqual(['table.plugin', 'shared.plugin', 'c.plugin']);
+  });
+
+  it('rejects unsafe mode regex patterns', () => {
+    expect(validateModeRegex('(a+)+$').valid).toBe(false);
+    expect(validateModeRegex('(x|x)+$').valid).toBe(false);
+    expect(validateModeRegex('(a|aa)+$').valid).toBe(false);
+  });
+
+  it('accepts long extension alternation lists', () => {
+    const pattern =
+      '^(ahk|ah1|ah2|ahk1|ahk2|zig|zon|gitignore|ignore|exclude|bib|ex|exs|eex|heex|leex|gs|graphql|graphqls|gql|dot|gv|hcl|tf|tfvars|ijs|janet|pkl|svelte|wgsl)$';
+
+    expect(validateModeRegex(pattern).valid).toBe(true);
+  });
+
+  it('does not match overly long mode keywords', () => {
+    expect(matchScore({ regex: '^a+$' }, 'a'.repeat(129))).toBe(0);
   });
 });

--- a/tests/unit/plugin-schema.test.js
+++ b/tests/unit/plugin-schema.test.js
@@ -1,6 +1,6 @@
 const path = require('node:path');
 const fs = require('node:fs');
-const { isValidPrice } = require('../../server/apis/plugin');
+const { getMatchingModeEntries, getModePluginIds, isValidPrice, matchScore } = require('../../server/apis/plugin');
 
 describe('plugin schema', () => {
   it('price field has correct bounds', () => {
@@ -26,5 +26,39 @@ describe('isValidPrice', () => {
 
   it('rejects values above MAX_PRICE', () => {
     expect(isValidPrice(10001)).toBe(false);
+  });
+});
+
+describe('mode plugin matching', () => {
+  it('matches multiple extensions with regex entries', () => {
+    const entry = { regex: '^(csv|tsv)$', pluginIds: ['table.plugin'] };
+
+    expect(matchScore(entry, 'csv')).toBeGreaterThan(0);
+    expect(matchScore(entry, 'tsv')).toBeGreaterThan(0);
+    expect(matchScore(entry, 'json')).toBe(0);
+  });
+
+  it('keeps legacy mode strings working', () => {
+    expect(matchScore({ mode: 'csv' }, 'csv')).toBeGreaterThan(0);
+    expect(matchScore({ mode: 'csv' }, 'json')).toBe(0);
+    expect(matchScore({ mode: 'c' }, 'csv')).toBe(0);
+  });
+
+  it('orders matching mode entries by score', () => {
+    const modes = [
+      { regex: 'c', pluginIds: ['c.plugin'] },
+      { regex: '^(csv|tsv)$', pluginIds: ['table.plugin'] },
+    ];
+
+    expect(getMatchingModeEntries(modes, 'csv').map((entry) => entry.pluginIds[0])).toEqual(['table.plugin', 'c.plugin']);
+  });
+
+  it('includes plugins from every matching mode entry', () => {
+    const modes = [
+      { regex: 'c', pluginIds: ['c.plugin', 'shared.plugin'] },
+      { regex: '^(csv|tsv)$', pluginIds: ['table.plugin', 'shared.plugin'] },
+    ];
+
+    expect(getModePluginIds(modes, 'csv')).toEqual(['table.plugin', 'shared.plugin', 'c.plugin']);
   });
 });


### PR DESCRIPTION
  - Fix admin user pagination/search by counting filtered results, encoding filters, showing empty states, and clamping invalid page/limit values
  - Add regex-based mode plugin mappings with validation while preserving legacy mode entries
  - Merge plugin IDs from all matching mode regexes in deterministic score order
  - Refresh admin pagination handlers and mode settings UI for regex entries
  - Update admin table styling and email template layout
  - Add unit coverage for regex mode matching and overlapping mode plugin IDs